### PR TITLE
[PAN-2570] Contract update to match 477 permissions bitmask update

### DIFF
--- a/contracts/Ingress.sol
+++ b/contracts/Ingress.sol
@@ -106,9 +106,9 @@ contract Ingress {
         bytes32 destinationEnodeLow,
         bytes16 destinationEnodeIp,
         uint16 destinationEnodePort
-    ) public view returns (bool) {
+    ) public view returns (bytes32) {
         if(getContractAddress(RULES_CONTRACT) == address(0)) {
-            return false;
+            return 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
         }
 
         return RulesProxy(registry[RULES_CONTRACT].contractAddress).connectionAllowed(

--- a/contracts/Rules.sol
+++ b/contracts/Rules.sol
@@ -128,8 +128,8 @@ contract Rules is AdminProxy, RulesProxy {
         bytes32 destinationEnodeLow,
         bytes16 destinationEnodeIp,
         uint16 destinationEnodePort
-    ) public view returns (bool) {
-        return (
+    ) public view returns (bytes32) {
+        if (
             enodeAllowed(
                 sourceEnodeHigh,
                 sourceEnodeLow,
@@ -141,7 +141,11 @@ contract Rules is AdminProxy, RulesProxy {
                 destinationEnodeIp,
                 destinationEnodePort
             )
-        );
+        ) {
+            return 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+        } else {
+            return 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+        }
     }
 
     // RULES - IS ENODE ALLOWED

--- a/contracts/RulesProxy.sol
+++ b/contracts/RulesProxy.sol
@@ -10,5 +10,5 @@ interface RulesProxy {
         bytes32 destinationEnodeLow,
         bytes16 destinationEnodeIp,
         uint16 destinationEnodePort
-    ) external view returns (bool);
+    ) external view returns (bytes32);
 }

--- a/test/test-ingress.js
+++ b/test/test-ingress.js
@@ -30,7 +30,7 @@ contract ('Ingress contract', (accounts) => {
             assert.equal(result, "0x0000000000000000000000000000000000000000", 'Rules contract should NOT be registered');
 
             let permitted = await ingressContract.connectionAllowed(nodeHigh, nodeLow, nodeHost, nodePort, node2High, node2Low, node2Host, node2Port);
-            assert.equal(permitted, false, 'expected connectionAllowed to return false');
+            assert.equal(permitted, "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 'expected connectionAllowed to return false');
         })
     }),
 

--- a/test/test-rules-proxy.js
+++ b/test/test-rules-proxy.js
@@ -47,7 +47,7 @@ contract ('Ingress contract with Rules proxy', () => {
           // Verify that the nodes are now able to talk
           result = await icProxy.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
           result2 = await rcProxy.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
-          assert.equal(result, true, "Connection SHOULD be allowed after Enodes have been registered");
+          assert.equal(result, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "Connection SHOULD be allowed after Enodes have been registered");
           assert.equal(result, result2, "Call and proxy call did NOT return the same value");
         });
 
@@ -78,7 +78,7 @@ contract ('Ingress contract with Rules proxy', () => {
           // Verify that the nodes are not permitted to talk
           result = await icProxy.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
           result2 = await rcProxy1.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
-          assert.equal(result, false, "Connection should NOT be allowed before Enodes have been registered");
+          assert.equal(result, "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "Connection should NOT be allowed before Enodes have been registered");
           assert.equal(result, result2, "Call and proxy call did NOT return the same value");
 
           // Add the two Enodes to the Rules register
@@ -88,7 +88,7 @@ contract ('Ingress contract with Rules proxy', () => {
           // Verify that the nodes are now able to talk
           result = await icProxy.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
           result2 = await rcProxy1.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
-          assert.equal(result, true, "Connection SHOULD be allowed after Enodes have been registered");
+          assert.equal(result, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "Connection SHOULD be allowed after Enodes have been registered");
           assert.equal(result, result2, "Call and proxy call did NOT return the same value");
 
           // Register the updated Rules contract
@@ -106,7 +106,7 @@ contract ('Ingress contract with Rules proxy', () => {
           // Verify that the nodes are not permitted to talk
           result = await icProxy.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
           result2 = await rcProxy2.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
-          assert.equal(result, false, "Connection should NOT be allowed before Enodes have been registered");
+          assert.equal(result, "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "Connection should NOT be allowed before Enodes have been registered");
           assert.equal(result, result2, "Call and proxy call did NOT return the same value");
         });
     });

--- a/test/test-rules.js
+++ b/test/test-rules.js
@@ -77,11 +77,11 @@ contract('Permissioning WITH AUTHORITY ', () => {
 
     it('Should allow a connection between 2 added nodes', async () => {
       let permitted = await proxy.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
-      assert.equal(permitted, true, 'expected permitted node1 <> node2');
+      assert.equal(permitted, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 'expected permitted node1 <> node2');
       permitted = await proxy.connectionAllowed(node1High, node1Low, node1Host, node1Port, node3High, node3Low, node3Host, node3Port);
-      assert.equal(permitted, true, 'expected permitted node1 <> node3');
+      assert.equal(permitted, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 'expected permitted node1 <> node3');
       permitted = await proxy.connectionAllowed(node2High, node2Low, node2Host, node2Port, node3High, node3Low, node3Host, node3Port);
-      assert.equal(permitted, true, 'expected permitted node2 <> node3');
+      assert.equal(permitted, "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 'expected permitted node2 <> node3');
     });
 
     it('Should remove a node from the whitelist and then NOT permit that node', async () => {
@@ -90,7 +90,7 @@ contract('Permissioning WITH AUTHORITY ', () => {
       assert.equal(permitted, false, 'expected removed node NOT permitted');
 
       permitted = await proxy.connectionAllowed(node1High, node1Low, node1Host, node1Port, node2High, node2Low, node2Host, node2Port);
-      assert.equal(permitted, false, 'expected source disallowed since it was removed');
+      assert.equal(permitted, "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 'expected source disallowed since it was removed');
     });
   });
 });


### PR DESCRIPTION
update the return values of the contract to match the new bitmasks of permissions as per the 477 proposal