### PR TITLE
OP-4: Add validation for existing admin account

### DIFF
--- a/src/components/AccountTab/AccountTab.tsx
+++ b/src/components/AccountTab/AccountTab.tsx
@@ -24,7 +24,7 @@ type AccountTab = {
   handleRemove: (value: any) => Promise<void>,
   isAdmin: boolean,
   deleteTransaction: () => void,
-  isValid: (address: string) => boolean,
+  isValid: (address: string) => object,
   isOpen: boolean,
   isReadOnly: boolean,
   pendingLock: boolean

--- a/src/components/Dashboard/__test__/__snapshots__/Dashboard.test.js.snap
+++ b/src/components/Dashboard/__test__/__snapshots__/Dashboard.test.js.snap
@@ -25150,7 +25150,11 @@ exports[`<Dashboard /> data ready tab=ADMIN_TAB matches snapshot 1`] = `
             input=""
             isOpen={false}
             modifyInput={[Function]}
-            validated={false}
+            validationResult={
+              Object {
+                "valid": false,
+              }
+            }
           >
             <Modal
               isOpen={false}
@@ -42479,7 +42483,11 @@ exports[`<Dashboard /> data ready tab=ENODE_TAB matches snapshot 1`] = `
             input=""
             isOpen={false}
             modifyInput={[Function]}
-            validated={false}
+            validationResult={
+              Object {
+                "valid": false,
+              }
+            }
           >
             <Modal
               isOpen={false}

--- a/src/components/Dashboard/__test__/__snapshots__/TabSelector.test.js.snap
+++ b/src/components/Dashboard/__test__/__snapshots__/TabSelector.test.js.snap
@@ -25150,7 +25150,11 @@ exports[`<Dashboard /> data ready tab=ADMIN_TAB matches snapshot 1`] = `
             input=""
             isOpen={false}
             modifyInput={[Function]}
-            validated={false}
+            validationResult={
+              Object {
+                "valid": false,
+              }
+            }
           >
             <Modal
               isOpen={false}
@@ -42479,7 +42483,11 @@ exports[`<Dashboard /> data ready tab=ENODE_TAB matches snapshot 1`] = `
             input=""
             isOpen={false}
             modifyInput={[Function]}
-            validated={false}
+            validationResult={
+              Object {
+                "valid": false,
+              }
+            }
           >
             <Modal
               isOpen={false}

--- a/src/components/Modals/Add.js
+++ b/src/components/Modals/Add.js
@@ -9,7 +9,7 @@ import styles from "./styles.module.scss";
 
 const AddModal = ({
     input,
-    validated,
+    validationResult,
     modifyInput,
     handleSubmit,
     isOpen,
@@ -39,7 +39,7 @@ const AddModal = ({
                         className={
                             input
                                 ? `${
-                                      validated
+                                      validationResult.valid
                                           ? styles.validField
                                           : styles.invalidField
                                   }`
@@ -62,12 +62,14 @@ const AddModal = ({
                         height="30px"
                         fontSize="14px"
                         className={
-                            !validated && input
+                            !validationResult.valid && input
                                 ? classnames(styles.errorMessage, styles.show)
                                 : styles.errorMessage
                         }
                     >
-                        {display.errorMessage}
+                        {validationResult.msg
+                            ? validationResult.msg
+                            : display.errorMessage}
                     </Text>
                 </Box>
                 <Flex
@@ -93,7 +95,7 @@ const AddModal = ({
                         hovercolor="#25D78F"
                         border={1}
                         onClick={handleSubmit}
-                        disabled={!validated}
+                        disabled={!validationResult.valid}
                     >
                         {display.submitText}
                     </Button>
@@ -105,7 +107,7 @@ const AddModal = ({
 
 AddModal.propTypes = {
     input: PropTypes.string.isRequired,
-    validated: PropTypes.bool.isRequired,
+    validationResult: PropTypes.object.isRequired,
     modifyInput: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
     isOpen: PropTypes.bool.isRequired,

--- a/src/containers/Modals/Add.js
+++ b/src/containers/Modals/Add.js
@@ -12,32 +12,32 @@ const AddModalContainer = ({
     display
 }) => {
     const [input, setInput] = useState("");
-    const [validated, setValidated] = useState(false);
+    const [validation, setValidation] = useState({ valid: false });
 
     const modifyInput = ({ target: { value } }) => {
-        const validated = isValid(value);
+        const validation = isValid(value);
         setInput(value);
-        setValidated(validated);
+        setValidation(validation);
     };
 
     const handleSubmit = e => {
         e.preventDefault();
         setInput("");
-        setValidated(false);
+        setValidation({ valid: false });
         handleAdd(input);
     };
 
     const handleClose = e => {
         e.preventDefault();
         setInput("");
-        setValidated(false);
+        setValidation({ valid: false });
         closeModal();
     };
 
     return (
         <AddModal
             input={input}
-            validated={validated}
+            validationResult={validation}
             modifyInput={modifyInput}
             handleSubmit={handleSubmit}
             isOpen={isOpen}

--- a/src/containers/Tabs/Account.tsx
+++ b/src/containers/Tabs/Account.tsx
@@ -98,6 +98,19 @@ const AccountTabContainer: React.FC<AccountTabContainerProps> = ({ isOpen }) => 
             });
     };
 
+    const isValidAccount = (address: string) => {
+        let isValidAddress = isAddress(address);
+        if (!isValidAddress) {
+            return {
+                valid: false
+            }
+        }
+
+        return {
+            valid: true
+        }
+    }
+
     return (
         <AccountTab
             list={list}
@@ -108,7 +121,7 @@ const AccountTabContainer: React.FC<AccountTabContainerProps> = ({ isOpen }) => 
             handleRemove={handleRemove}
             isAdmin={isAdmin}
             deleteTransaction={deleteTransaction}
-            isValid={isAddress}
+            isValid={isValidAccount}
             isOpen={isOpen}
             isReadOnly={isReadOnly}
             pendingLock={!!transactions.get("lock")}

--- a/src/containers/Tabs/Admin.js
+++ b/src/containers/Tabs/Admin.js
@@ -94,6 +94,27 @@ const AdminTabContainer = ({ isOpen }) => {
             });
     };
 
+    const isValidAdmin = address => {
+        let isValidAddress = isAddress(address);
+        if (!isValidAddress) {
+            return {
+                valid: false
+            };
+        }
+
+        let isAdmin = list.filter(item => item.address === address).length > 0;
+        if (isAdmin) {
+            return {
+                valid: false,
+                msg: "Account address is already an admin."
+            };
+        }
+
+        return {
+            valid: true
+        };
+    };
+
     return (
         <AdminTab
             list={list}
@@ -104,7 +125,7 @@ const AdminTabContainer = ({ isOpen }) => {
             handleRemove={handleRemove}
             isAdmin={isAdmin}
             deleteTransaction={deleteTransaction}
-            isValid={isAddress}
+            isValid={isValidAdmin}
             isOpen={isOpen}
         />
     );

--- a/src/util/enodetools.js
+++ b/src/util/enodetools.js
@@ -64,5 +64,7 @@ export const identifierToEnodeHighAndLow = identifier => {
 export const isValidEnode = str => {
     const params = enodeToParams(str);
     const hasValues = !Object.values(params).some(value => !value);
-    return hasValues;
+    return {
+        valid: hasValues
+    };
 };


### PR DESCRIPTION
Updated the input validation functions to return an object instead of just a boolean.
The validation result object looks like this:

```
{
  valid: boolean,
  msg: string
}
```

When displaying the validation error, if a msg is specified in the validation result object, we use that message. If it is not, we use the default error message for that field.