### PR TITLE
[OP-37] Added address lowercasing for string matching.

### DIFF
--- a/src/context/accountData.tsx
+++ b/src/context/accountData.tsx
@@ -78,7 +78,7 @@ export const useAccountData = () => {
     const formattedAccountWhitelist = useMemo(() => {
         return accountWhitelist
             ? accountWhitelist
-                  .map(account => ({ ...account, status: "active" }))
+                  .map(account => ({ ...account, identifier: account.address.toLowerCase(), status: "active" }))
                   .reverse()
             : undefined
     }, [accountWhitelist])

--- a/src/context/adminData.tsx
+++ b/src/context/adminData.tsx
@@ -72,7 +72,7 @@ export const useAdminData = () => {
             ? admins
                   .map(address => ({
                       address,
-                      identifier: address,
+                      identifier: address.toLowerCase(),
                       status: "active"
                   }))
                   .reverse()


### PR DESCRIPTION
The code removing the `pending` additions is String matching on an `identifier` field, which was not defined correctly.  

Account data was missing `identifier`; and the account address needs to be converted to lowercase to accommodate for the case changing performed during checksum calculation.