### PR TITLE
[Bug] debounced modal openers so they don't receive the dom element

### DIFF
--- a/src/components/AccountTab/AccountTab.tsx
+++ b/src/components/AccountTab/AccountTab.tsx
@@ -15,7 +15,7 @@ type AccountTab = {
   list: any[],
   userAddress?: string,
   modals: {
-    add: boolean | object,
+    add: boolean,
     remove: boolean | string,
     lock: boolean
   },
@@ -79,7 +79,7 @@ AccountTab.propTypes = {
     list: PropTypes.array.isRequired,
     userAddress: PropTypes.string,
     modals: PropTypes.shape({
-      add: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]).isRequired,
+      add: PropTypes.bool.isRequired,
       remove: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]).isRequired,
       lock: PropTypes.bool.isRequired
     }).isRequired,

--- a/src/components/AccountTab/TableHeader.tsx
+++ b/src/components/AccountTab/TableHeader.tsx
@@ -30,7 +30,7 @@ const TableHeader: React.FC<TableHeader> = ({ number, openAddModal, disabledAdd 
             <Button
                 icon="AddCircleOutline"
                 mainColor="#25D78F"
-                onClick={openAddModal}
+                onClick={() => openAddModal()}
                 disabled={disabledAdd}
             >
                 Add Whitelisted Account

--- a/src/components/AdminTab/TableHeader.js
+++ b/src/components/AdminTab/TableHeader.js
@@ -13,7 +13,7 @@ const TableHeader = ({ number, openAddModal, disabledAdd }) => (
             <Button
                 icon="AddCircleOutline"
                 mainColor="#25D78F"
-                onClick={openAddModal}
+                onClick={() => openAddModal()}
                 disabled={disabledAdd}
             >
                 Add Admin Account

--- a/src/components/EnodeTab/TableHeader.js
+++ b/src/components/EnodeTab/TableHeader.js
@@ -26,7 +26,7 @@ const TableHeader = ({
                 mr={3}
                 icon="AddCircleOutline"
                 mainColor="#25D78F"
-                onClick={openAddModal}
+                onClick={() => openAddModal()}
                 disabled={disabledAdd}
             >
                 Add Whitelisted Node
@@ -40,7 +40,7 @@ const TableHeader = ({
                     <Button.Outline
                         icon="LockOpen"
                         mainColor="black"
-                        onClick={openLockModal}
+                        onClick={() => openLockModal()}
                         disabled={disabledLock}
                         className={styles.lockButton}
                     >
@@ -57,7 +57,7 @@ const TableHeader = ({
                     <Button
                         variant="danger"
                         icon="Lock"
-                        onClick={openLockModal}
+                        onClick={() => openLockModal()}
                         disabled={disabledLock}
                     >
                         Allow Changes


### PR DESCRIPTION
modal opening functions were being passed bare into the buttons which means they were being supplied the button dom element as an argument when triggered. This was triggering a type warning down the tree when it turned out that the dom element isn't a boolean as expected, but is truthy so ended up working by accident.

Decoupled them so the argument is discarded.