### PR TITLE
[OP-67] Deployed admin before the rules contracts then look it up

### DIFF
--- a/migrations/2_deploy_admin_contract.js
+++ b/migrations/2_deploy_admin_contract.js
@@ -1,0 +1,8 @@
+const Web3Utils = require("web3-utils");
+
+const Admin = artifacts.require("./Admin.sol");
+
+module.exports = async(deployer, network) => {
+    await deployer.deploy(Admin);
+    console.log("   > Admin contract deployed with address = " + Admin.address);
+}

--- a/migrations/3_deploy_node_ingress_rules_contract.js
+++ b/migrations/3_deploy_node_ingress_rules_contract.js
@@ -28,10 +28,9 @@ module.exports = async(deployer, network) => {
         console.error("   > Predeployed NodeIngress contract is not responding like an NodeIngress contract at address = " + nodeIngress);
     }
 
-    await deployer.deploy(Admin);
-    console.log("   > Admin contract deployed");
-    await nodeIngressInstance.setContractAddress(adminContractName, Admin.address);
-    console.log("   > Updated NodeIngress with Admin  address = " + Admin.address);
+    const admin = await Admin.deployed()
+    await nodeIngressInstance.setContractAddress(adminContractName, admin.address);
+    console.log("   > Updated NodeIngress with Admin  address = " + admin.address);
 
     await deployer.deploy(NodeRules, nodeIngress);
     console.log("   > NodeRules deployed with NodeIngress.address = " + nodeIngress);

--- a/migrations/4_deploy_account_ingress_rules_contract.js
+++ b/migrations/4_deploy_account_ingress_rules_contract.js
@@ -28,10 +28,9 @@ module.exports = async(deployer, network) => {
         console.error("   > Predeployed AccountIngress contract is not responding like an AccountIngress contract at address = " + accountIngress);
     }
 
-    await deployer.deploy(Admin);
-    console.log("   > Admin contract deployed");
-    await accountIngressInstance.setContractAddress(adminContractName, Admin.address);
-    console.log("   > Updated AccountIngress with Admin  address = " + Admin.address);
+    const admin = await Admin.deployed();
+    await accountIngressInstance.setContractAddress(adminContractName, admin.address);
+    console.log("   > Updated AccountIngress with Admin  address = " + admin.address);
 
     await deployer.deploy(Rules, accountIngress);
     console.log("   > Rules deployed with AccountIngress.address = " + accountIngress);


### PR DESCRIPTION
We were deploying 2 seperate admin contracts, dapp would only display and adjust 1 of them. Needed to deploy just 1 of them and point everything towards it.