### PR TITLE
env wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "test": "yarn run test:contracts && yarn run test:app",
     "coverage:contracts": "yarn solidity-coverage",
     "coverage": "yarn run coverage:contracts",
-    "build:app": "yarn react-scripts build",
+    "build:app": "sh scripts/wrap_env.sh 'yarn react-scripts build'",
     "build:contracts": "yarn truffle compile && yarn typechain --target ethers --outDir ./src/chain/@types 'src/chain/abis/*.json'",
     "build": "yarn run build:contracts && yarn run build:app",
-    "start": "yarn react-scripts start",
+    "start": "sh scripts/wrap_env.sh 'yarn react-scripts start'",
     "eject": "yarn react-scripts eject"
   },
   "eslintConfig": {

--- a/scripts/wrap_env.sh
+++ b/scripts/wrap_env.sh
@@ -1,0 +1,7 @@
+# Load up .env
+set -o allexport
+[[ -f .env ]] && source .env
+set +o allexport
+export REACT_APP_ACCOUNT_INGRESS_CONTRACT_ADDRESS=$ACCOUNT_INGRESS_CONTRACT_ADDRESS
+export REACT_APP_NODE_INGRESS_CONTRACT_ADDRESS=$NODE_INGRESS_CONTRACT_ADDRESS
+$@

--- a/src/util/configLoader.ts
+++ b/src/util/configLoader.ts
@@ -26,8 +26,8 @@ const loadConfig = async (): Promise<Config> => {
     // We're cheating here by knowing what truffle will write when it's running a ganache server.
     // We're forcing the types because we know what the network entry in the json file will look like so long as it's there.
     let accountIngressAddress;
-    if (process.env.ACCOUNT_INGRESS_CONTRACT_ADDRESS) {
-      accountIngressAddress = process.env.ACCOUNT_INGRESS_CONTRACT_ADDRESS;
+    if (process.env.REACT_APP_ACCOUNT_INGRESS_CONTRACT_ADDRESS) {
+      accountIngressAddress = process.env.REACT_APP_ACCOUNT_INGRESS_CONTRACT_ADDRESS;
     } else {
       const accountIngressNetworks = Object.values(AccountIngress.networks);
       if (accountIngressNetworks.length === 0) {
@@ -37,8 +37,8 @@ const loadConfig = async (): Promise<Config> => {
     }
 
     let nodeIngressAddress;
-    if (process.env.NODE_INGRESS_CONTRACT_ADDRESS) {
-      nodeIngressAddress = process.env.NODE_INGRESS_CONTRACT_ADDRESS;
+    if (process.env.REACT_APP_NODE_INGRESS_CONTRACT_ADDRESS) {
+      nodeIngressAddress = process.env.REACT_APP_NODE_INGRESS_CONTRACT_ADDRESS;
     } else {
       const nodeIngressNetworks = Object.values(NodeIngress.networks);
       if (nodeIngressNetworks.length === 0) {
@@ -47,7 +47,7 @@ const loadConfig = async (): Promise<Config> => {
       nodeIngressAddress = (nodeIngressNetworks[0] as { address: string }).address;
     }
 
-    // if we haven't errored by this point then we're being driven by end and until we do it better we should accept any network
+    // if we haven't errored by this point then we're being driven by env and until we do it better we should accept any network
     const nodeIngressNetworkId = Object.keys(NodeIngress.networks)[0]
       ? (Object.keys(NodeIngress.networks)[0] as string)
       : 'any';


### PR DESCRIPTION
In the development server we want to read the same env variables that we use during contract deployment. create-react-app won't let us read anything not prefixed with REACT_APP_.
This adds a wrapper script that re-exports the nessecary env variables with the prefix.