### PR TITLE
Make the env wrapper script work on more environments

### DIFF
--- a/scripts/wrap_env.sh
+++ b/scripts/wrap_env.sh
@@ -1,6 +1,6 @@
 # Load up .env
 set -o allexport
-[[ -f .env ]] && source .env
+if [ -f .env ]; then source .env; fi
 set +o allexport
 export REACT_APP_ACCOUNT_INGRESS_CONTRACT_ADDRESS=$ACCOUNT_INGRESS_CONTRACT_ADDRESS
 export REACT_APP_NODE_INGRESS_CONTRACT_ADDRESS=$NODE_INGRESS_CONTRACT_ADDRESS


### PR DESCRIPTION
After troubleshooting we discovered the original version of the env script doesn't work on ubuntu's sh which is dash.

Feel free to approve but don't merge in my absence