### PR TITLE
Allow for the tag-based creation of a GitHub release to actually work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
           root: ./
           paths:
             - distribution/
+            - build/
       - store_artifacts:
           name: Distributions
           path: distribution/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
               -u ${CIRCLE_PROJECT_USERNAME} \
               -r ${CIRCLE_PROJECT_REPONAME} \
               -c ${CIRCLE_SHA1} \
-              ./distributions/
+              ./distribution/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,7 @@ jobs:
               -u ${CIRCLE_PROJECT_USERNAME} \
               -r ${CIRCLE_PROJECT_REPONAME} \
               -c ${CIRCLE_SHA1} \
+              ${CIRCLE_TAG} \
               ./distribution/
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,8 @@ jobs:
           working_directory: build
           command: |
             mkdir -p ../distribution
-            tar -czvf ../permissioning-smart-contracts-$(git describe).tar.gz *
-            zip -R ../permissionin-smart-contracts-$(git describe).zip *
+            tar -czvf ../distribution/permissioning-smart-contracts-$(git describe).tar.gz *
+            zip -R ../distribution/permissionin-smart-contracts-$(git describe).zip *
       - persist_to_workspace:
           root: ./
           paths:


### PR DESCRIPTION
This was mostly around getting the `ghr` tool to work well and ensuring
that we were persisting the correct details between jobs